### PR TITLE
GP-11723 #comment Add support to Redis 5.x

### DIFF
--- a/galactic-senate.gemspec
+++ b/galactic-senate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0', '< 2.0'
-  spec.add_runtime_dependency 'redis', '>= 3.3.0', '< 7.0'
+  spec.add_runtime_dependency 'redis', '>= 3.3.0', '< 6.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/galactic-senate.gemspec
+++ b/galactic-senate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0', '< 2.0'
-  spec.add_runtime_dependency 'redis', '>= 3.3.0', '< 5.0'
+  spec.add_runtime_dependency 'redis', '>= 3.3.0', '< 7.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Updates Redis dependency to `>= 5.0` (from `>= 3.3.0`).  